### PR TITLE
Fix Bug/inline model swagger docs

### DIFF
--- a/handlers/_swagger.js
+++ b/handlers/_swagger.js
@@ -20,7 +20,7 @@ exports.init = function (app, auth, config, logger, serviceLoader, swagger, call
     var useLocalhost = cfg.useLocalhost;
     var context = cfg.context;
 
-    var specs = swagger.getSpecs();
+    var specs = swagger.getPrettySpecs();
     _.keys(specs).forEach(function(specName) {
         var api = specs[specName];
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "debug": "^2.2.0",
     "express": "^4.12.4",
     "express-static": "^1.0.3",
+    "json-schema-deref": "^0.2.5",
     "jsonwebtoken": "^5.4.1",
     "lodash": "^3.9.3",
     "multer": "^1.1.0",

--- a/services/swagger.js
+++ b/services/swagger.js
@@ -8,8 +8,13 @@ var fs = require('fs');
 var debug = require('debug')('swagger');
 var async = require('async');
 var parser = require('swagger-parser');
+var deref = require('json-schema-deref');
 
-var specs = {};
+var specs = {
+    dereferenced: {},
+    bundled: {}
+};
+
 
 exports.init = function(logger, callback) {
 
@@ -45,7 +50,7 @@ exports.init = function(logger, callback) {
     //For each model, parse it, and automatically hook up the routes to the appropriate handler
     async.eachSeries(files, function parseSwagger(file, swagCallback) {
 
-        parser.dereference(file, function (err, api, metadata) {
+        parser.bundle(file, function (err, api, metadata) {
 
             if (err && path.extname(file) === '.yaml') {
                 return swagCallback(err);
@@ -74,7 +79,15 @@ exports.init = function(logger, callback) {
             var handlerName = path.basename(file); //use the swagger filename as our handler module id
             handlerName = handlerName.substring(0, handlerName.lastIndexOf('.')); //strip extensions
 
-            specs[handlerName] = api;
+            specs.bundled[handlerName] = api;
+            deref(api, function (err, apiAsPlainJson) {
+                if (err) {
+                    logger.error('Failed dereferencing swagger spec: ' + file);
+                    return swagCallback(err);
+                }
+                specs.dereferenced[handlerName] = apiAsPlainJson;
+            });
+            
 
             return swagCallback();
         });
@@ -84,8 +97,12 @@ exports.init = function(logger, callback) {
 
 };
 
-exports.getSpecs = function() {
-    return specs;
+exports.getSimpleSpecs = function() {
+    return specs.dereferenced;
+};
+
+exports.getPrettySpecs = function () {
+    return specs.bundled;
 };
 
 //Try to determine if this is supposed to be a swagger file

--- a/services/swagger.js
+++ b/services/swagger.js
@@ -86,10 +86,8 @@ exports.init = function(logger, callback) {
                     return swagCallback(err);
                 }
                 specs.dereferenced[handlerName] = apiAsPlainJson;
+                return swagCallback();
             });
-            
-
-            return swagCallback();
         });
     }, function(err) {
         callback(err);


### PR DESCRIPTION
When Swagger-UI displays a swagger doc generated by `dereference()`, it has no context for the various models, so it calls them things like `inline_model_4`.

If we use `bundle()` instead, Swagger-UI will use the reference name so it can be called something like `PriceEstimate`.

Since there are/maybe other cases where a plain JSON (i.e. no `$ref`) version of the spec is desired, we then use a basic [JSON dereferencer](https://github.com/bojand/json-schema-deref) to get the inlined version.

Now that there are 2 styles of the specs, there are 2 functions to get them:
- `getSimpleSpecs` (which returns the fully dereferenced versions)
- `getPrettySpecs` (which returns the ones that are good for swagger-ui)

Currently, the `swagger` handler uses `getPrettySpecs`