### PR TITLE
Use swagger-parser.validate() to get the dereferenced spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueoak-server",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "BlueOak Server",
   "repository": {
     "type": "git",
@@ -44,7 +44,6 @@
     "debug": "^2.2.0",
     "express": "^4.12.4",
     "express-static": "^1.0.3",
-    "json-schema-deref": "^0.2.5",
     "jsonwebtoken": "^5.4.1",
     "lodash": "^3.9.3",
     "multer": "^1.1.0",


### PR DESCRIPTION
resolves startup failure caused by "too many" swagger specs being processed:
`RangeError: Maximum call stack size exceeded`

* was caused by the algorithm in `json-deref-schema`
* simplified to use existing dependency `swagger-parser` instead

also revised isBlueOakProject():
* don't bother stat()ing `../common/swagger`if the basename isn't `server`
* if we do stat it, check that it is a directory