### PR TITLE
Response validation level fail

### DIFF
--- a/examples/swagger/handlers/api-v1.js
+++ b/examples/swagger/handlers/api-v1.js
@@ -1,0 +1,16 @@
+exports.init = function() {
+
+};
+
+exports.getFunTimeById = function(req, res, next) {
+    res.status(200).json({
+        'curiousPeople': [
+            {
+                'kind': 'OtherPerson',
+                'curiousPersonReqField': 'hey!',
+                'enthusiasticPersonReqField': 'hola!'
+            }
+        ]
+    });
+};
+

--- a/examples/swagger/swagger/public/paths/superfuntime-{id}.yaml
+++ b/examples/swagger/swagger/public/paths/superfuntime-{id}.yaml
@@ -1,5 +1,6 @@
 get:
   summary: Get super fun time
+  operationId: getFunTimeById
   tags:
     - Fun Times
   parameters:

--- a/handlers/_swagger.js
+++ b/handlers/_swagger.js
@@ -260,7 +260,7 @@ function registerRoute(app, auth, additionalMiddleware, method, path, data, allo
                     var isJson = typeof body === 'string'; //body can come in as JSON or object, we want object
                     body = isJson ? JSON.parse(body) : body;
                     var validationErrors, invalidBody;
-                    validationErrors = validateResponseModels(res, body, data, logger);
+                    validationErrors = validateResponseModels(res, body, data, swaggerDoc, logger);
                     if (validationErrors) {
                         if (responseModelValidationLevel === 'error' || responseModelValidationLevel === 'fail') {
                             //we're going to check the model and send any valdiation errors back to the caller in the reponse
@@ -279,7 +279,7 @@ function registerRoute(app, auth, additionalMiddleware, method, path, data, allo
                                     }
                                 } else {
                                     body = body || {};
-                                    body._response_validation_errors = validationErrors;
+                                    body._response_validation_errors = _.clone(validationErrors);
                                 }
                             }
                             else {//level is fail
@@ -440,7 +440,7 @@ function validateRequestParameters(req, data, swaggerDoc, logger, callback) {
     return callback();
 }
 
-function validateResponseModels(res, body, data, logger, swaggerDoc) {
+function validateResponseModels(res, body, data, swaggerDoc, logger) {
     if (!(res.statusCode >= 200 && res.statusCode < 300 || res.statusCode >= 400 && res.statusCode < 500)) {
         //the statusCode for the response isn't in the range that we'd expect to be documented in the swagger
         //i.e.: 200-299 (success) or 400-499 (request error)

--- a/handlers/_swagger.js
+++ b/handlers/_swagger.js
@@ -286,7 +286,7 @@ function registerRoute(app, auth, additionalMiddleware, method, path, data, allo
                             statusCode: res.statusCode,
                             body: invalidBody || body
                         };
-                        logger[responseModelValidationLevel === "warn" ? "warn" : "error"]('Response validation error:', JSON.stringify(validationErrors, null, 2));
+                        logger[responseModelValidationLevel === 'warn' ? 'warn' : 'error']('Response validation error:', JSON.stringify(validationErrors, null, 2));
                     }
                     
                     //after this initial call (sometimes `send` will call itself again), we don't need to get the response for validation anymore

--- a/services/swagger.js
+++ b/services/swagger.js
@@ -21,7 +21,7 @@ var httpMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch'];
 
 exports.init = function(logger, config, callback) {
     var cfg = config.get('swagger');
-    var responseModelValidationLevel = /error|warn/.test(cfg.validateResponseModels) ? cfg.validateResponseModels : 0;
+    var responseModelValidationLevel = /error|warn|fail/.test(cfg.validateResponseModels) ? cfg.validateResponseModels : 0;
     var swaggerDir = null;
     if (isBlueoakProject()) {
         swaggerDir = path.resolve(global.__appDir, '../common/swagger');

--- a/services/swagger.js
+++ b/services/swagger.js
@@ -18,10 +18,19 @@ var specs = {
 
 var httpMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch'];
 
+var responseModelValidationLevel;
+var polymorphicValidation;
 
 exports.init = function(logger, config, callback) {
     var cfg = config.get('swagger');
-    var responseModelValidationLevel = /error|warn|fail/.test(cfg.validateResponseModels) ? cfg.validateResponseModels : 0;
+    responseModelValidationLevel = /error|warn|fail/.test(cfg.validateResponseModels) ? cfg.validateResponseModels : 0;
+    polymorphicValidation = (cfg.polymorphicValidation !== false);//default to true
+    if (responseModelValidationLevel) {
+        logger.info('Response model validation is on and set to level "%s"', responseModelValidationLevel);
+    }
+    if (!polymorphicValidation) {
+        logger.info('Polymorphic validation is OFF"');
+    }
     var swaggerDir = null;
     if (isBlueoakProject()) {
         swaggerDir = path.resolve(global.__appDir, '../common/swagger');
@@ -89,6 +98,18 @@ exports.init = function(logger, config, callback) {
         callback(err);
     });
 
+};
+
+exports.getResponseModelValidationLevel = function () {
+    return responseModelValidationLevel;
+};
+
+exports.isPolyMorphicValidation = function () {
+    return polymorphicValidation;
+};
+
+exports.getValidHttpMethods = function () {
+    return httpMethods;
 };
 
 exports.getSimpleSpecs = function() {

--- a/test/integration/fixtures/server11/config/default.json
+++ b/test/integration/fixtures/server11/config/default.json
@@ -1,0 +1,32 @@
+{
+  "express": {
+    "port": "5000",
+    "middleware": ["session", "bodyParser"]
+  },
+
+  "cluster": {
+    "maxWorkers": 1
+  },
+
+  "session": {
+    "keys": ["sessionkey"]
+  },
+
+  "bodyParser": {
+    "json": {}
+  },
+
+  "logger": {
+    "transports": [
+      {
+        "package": "winston",
+        "field": "transports.Console",
+        "options": {
+          "level": "debug",
+          "colorize": true,
+          "timestamp": true
+        }
+      }
+    ]
+  }
+}

--- a/test/integration/fixtures/server11/config/test-response-validation-errors.json
+++ b/test/integration/fixtures/server11/config/test-response-validation-errors.json
@@ -1,0 +1,5 @@
+{
+  "swagger": {
+    "validateResponseModels": "fail"
+  }
+}

--- a/test/integration/fixtures/server11/handlers/foo.js
+++ b/test/integration/fixtures/server11/handlers/foo.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2015-2016 PointSource, LLC.
+ * MIT Licensed
+ */
+exports.pets5 = function(req, res, next) {
+    res.json({name: 'pets5'});
+};

--- a/test/integration/fixtures/server11/handlers/petstore.js
+++ b/test/integration/fixtures/server11/handlers/petstore.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2015-2016 PointSource, LLC.
+ * MIT Licensed
+ */
+exports.pets1 = function (req, res, next) {
+    res.send({
+        name: 'pets1',
+        id: 1
+    });
+};
+
+exports.pets2 = function (req, res, next) {
+    res.send({
+        name: 'pets2'
+    });
+};
+
+exports.pets3 = function (req, res, next) {
+    res.json({
+        name: 'pets3'
+    });
+};
+
+exports.pets4 = function (req, res, next) {
+    res.json({
+        name: 'pets4'
+    });
+};
+
+exports.pets22 = function (req, res, next) {
+    res.status(201).send(req.body);
+};

--- a/test/integration/fixtures/server11/swagger/petstore.json
+++ b/test/integration/fixtures/server11/swagger/petstore.json
@@ -1,0 +1,191 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://helloreverb.com/terms/",
+    "contact": {
+      "name": "Wordnik API Team",
+      "email": "foo@example.com",
+      "url": "http://madskristensen.net"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+    }
+  },
+  "host": "petstore.swagger.wordnik.com",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets1": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "pets1",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/pets3": {
+      "get": {
+        "x-middleware": "pets3",
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "pets1",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/pets4": {
+      "get": {
+        "x-middleware": ["pets4"],
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "pets1",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/pets5": {
+      "get": {
+        "x-middleware": ["foo.pets5"],
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "pets1",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "newPet": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/pet"
+        },
+        {
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "errorModel": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/test/integration/fixtures/server11/swagger/petstore2.json
+++ b/test/integration/fixtures/server11/swagger/petstore2.json
@@ -1,0 +1,143 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://helloreverb.com/terms/",
+    "contact": {
+      "name": "Wordnik API Team",
+      "email": "foo@example.com",
+      "url": "http://madskristensen.net"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+    }
+  },
+  "host": "petstore.swagger.wordnik.com",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets2": {
+      "x-handler": "petstore",
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "pets2",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Adds a new pet",
+        "operationId": "pets22",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "new pet object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "pet added",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "422": {
+            "description": "Request Validation Error"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "newPet": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/pet"
+        },
+        {
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "errorModel": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -19,8 +19,9 @@ exports.launch = function (fixtureName, opts, done) {
     }
 
     var output = '';
+    var bosPath = path.resolve(__dirname, opts.exec);
     if (process.platform === 'win32') {
-        lastLaunch = child_process.exec(path.resolve(__dirname, opts.exec),
+        lastLaunch = child_process.exec('node ' + bosPath,
             {
                 'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
                 'env': opts.env
@@ -33,7 +34,7 @@ exports.launch = function (fixtureName, opts, done) {
             });
     }
     else {
-        lastLaunch = child_process.execFile(path.resolve(__dirname, opts.exec), [],
+        lastLaunch = child_process.execFile(bosPath, [],
             {
                 'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
                 'env': opts.env

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -20,32 +20,18 @@ exports.launch = function (fixtureName, opts, done) {
 
     var output = '';
     var bosPath = path.resolve(__dirname, opts.exec);
-    if (process.platform === 'win32') {
-        lastLaunch = child_process.exec('node ' + bosPath,
-            {
-                'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
-                'env': opts.env
-            },
-            function (err, stdout, stderr) {
-                if (err) {
-                    console.warn(err, stderr);
-                }
-                output += stdout + stderr;
-            });
-    }
-    else {
-        lastLaunch = child_process.execFile(bosPath, [],
-            {
-                'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
-                'env': opts.env
-            },
-            function (err, stdout, stderr) {
-                if (err) {
-                    console.warn(err, stderr);
-                }
-                output += stdout + stderr;
-            });
-    }
+    lastLaunch = child_process.exec('node ' + bosPath,
+        {
+            'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
+            'env': opts.env
+        },
+        function (err, stdout, stderr) {
+            if (err) {
+                console.warn(err, stderr);
+            }
+            output += stdout + stderr;
+        }
+    );
     setTimeout(function () {
         output = output.length > 50 ? output : null; //if output > 50, probably contains a stack tracegu
         done(output);

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -19,17 +19,32 @@ exports.launch = function (fixtureName, opts, done) {
     }
 
     var output = '';
-    lastLaunch = child_process.execFile(path.resolve(__dirname, opts.exec), [],
-        {
-            'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
-            'env': opts.env
-        },
-        function (err, stdout, stderr) {
-            if (err) {
-                console.warn(err, stderr);
-            }
-            output += stdout + stderr;
-        });
+    if (process.platform === 'win32') {
+        lastLaunch = child_process.exec(path.resolve(__dirname, opts.exec),
+            {
+                'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
+                'env': opts.env
+            },
+            function (err, stdout, stderr) {
+                if (err) {
+                    console.warn(err, stderr);
+                }
+                output += stdout + stderr;
+            });
+    }
+    else {
+        lastLaunch = child_process.execFile(path.resolve(__dirname, opts.exec), [],
+            {
+                'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
+                'env': opts.env
+            },
+            function (err, stdout, stderr) {
+                if (err) {
+                    console.warn(err, stderr);
+                }
+                output += stdout + stderr;
+            });
+    }
     setTimeout(function () {
         output = output.length > 50 ? output : null; //if output > 50, probably contains a stack tracegu
         done(output);
@@ -37,8 +52,14 @@ exports.launch = function (fixtureName, opts, done) {
 };
 
 exports.finish = function (done) {
-    lastLaunch.kill('SIGINT');
+    if (process.platform === 'win32') {
+        child_process.exec('taskkill /PID ' + lastLaunch.pid + ' /T /F');
+    }
+    else {
+        lastLaunch.kill('SIGINT');
+    }
     setTimeout(function () {
         done();
     }, 2500);
 };
+

--- a/test/integration/testSwagger.js
+++ b/test/integration/testSwagger.js
@@ -265,12 +265,12 @@ describe('SERVER5 + response validation "error" - test validation of response mo
     });
 });
 
-describe.only('SERVER11 + response validation "error" - test validation of response models using the "fail" option', function () {
+describe('SERVER11 + response validation "error" - test validation of response models using the "fail" option', function () {
     this.timeout(5000);
 
     before(function (done) {
         process.env.NODE_ENV = 'test-response-validation-errors';
-        util.launch('server11', { env: process.env, exec: 'C:/Users/shepp/AppData/Roaming/npm/blueoak-server.cmd'}, done);
+        util.launch('server11', { env: process.env }, done);
     });
 
     after(function (done) {

--- a/test/integration/testSwagger.js
+++ b/test/integration/testSwagger.js
@@ -252,7 +252,53 @@ describe('SERVER5 + response validation "error" - test validation of response mo
             assert.equal(json.id, undefined);
             assert.deepEqual(json._response_validation_errors, {
                 'message': 'Error validating response body for GET /api/pets2 with status code 200',
-                'status': 422,
+                'status': 522,
+                'type': 'ValidationError',
+                'validation_errors': [
+                    {
+                        'message': 'Missing required property: id'
+                    }
+                ]
+            });
+            done();
+        });
+    });
+});
+
+describe.only('SERVER11 + response validation "error" - test validation of response models using the "fail" option', function () {
+    this.timeout(5000);
+
+    before(function (done) {
+        process.env.NODE_ENV = 'test-response-validation-errors';
+        util.launch('server11', { env: process.env, exec: 'C:/Users/shepp/AppData/Roaming/npm/blueoak-server.cmd'}, done);
+    });
+
+    after(function (done) {
+        process.env.NODE_ENV = undefined;
+        util.finish(done);
+    });
+
+    it('GET /api/pets1 - no validation error', function (done) {
+        request('http://localhost:' + (process.env.PORT || 5000) + '/api/pets1', function (err, resp, body) {
+            assert.ok(!err);
+            var json = JSON.parse(body);
+            assert.equal(json.name, 'pets1');
+            assert.equal(json.id, 1);
+            assert.equal(json.response, undefined);
+            assert.equal(json.validationErrors, undefined);
+            done();
+        });
+    });
+
+    it('GET /api/pets2 - validation error', function (done) {
+        request('http://localhost:' + (process.env.PORT || 5000) + '/api/pets2', function (err, resp, body) {
+            assert.ok(!err);
+            var json = JSON.parse(body);
+            assert.equal(resp.statusCode, 522);
+            assert.notEqual(json.response, undefined);
+            assert.deepEqual(json.validationErrors, {
+                'message': 'Error validating response body for GET /api/pets2 with status code 200',
+                'status': 522,
                 'type': 'ValidationError',
                 'validation_errors': [
                     {


### PR DESCRIPTION
Added new response validation level 'fail' that changes the actual http response code to 522 and separates out the validation errors and response body. May break client code, so this should only be used when developing/testing an API in stand alone.