### PR TITLE
override inherited properties

### DIFF
--- a/examples/swagger/swagger/public/definitions/CuriousPerson.yaml
+++ b/examples/swagger/swagger/public/definitions/CuriousPerson.yaml
@@ -7,5 +7,7 @@ allOf:
     properties:
       kind:
         type: string
+        enum:
+          - CuriousPerson
       curiousPersonReqField:
         type: string

--- a/examples/swagger/swagger/public/definitions/EnthusiasticPerson.yaml
+++ b/examples/swagger/swagger/public/definitions/EnthusiasticPerson.yaml
@@ -7,6 +7,8 @@ allOf:
     properties:
       kind:
         type: string
+        enum:
+          - EnthusiasticPerson
       enthusiasticPersonReqField:
         type: string
 

--- a/examples/swagger/swagger/public/definitions/Person.yaml
+++ b/examples/swagger/swagger/public/definitions/Person.yaml
@@ -7,6 +7,4 @@ allOf:
     properties:
       kind:
         type: string
-        enum:
-         - AngryPerson
 

--- a/examples/swagger/swagger/public/definitions/Person.yaml
+++ b/examples/swagger/swagger/public/definitions/Person.yaml
@@ -7,4 +7,6 @@ allOf:
     properties:
       kind:
         type: string
+        enum:
+         - AngryPerson
 

--- a/lib/swaggerUtil.js
+++ b/lib/swaggerUtil.js
@@ -158,10 +158,6 @@ function castValueFromString(schema, value) {
 
 exports.cast = castValueFromString;
 
-exports.deepClone = function (obj) {
-    return _.cloneDeep(obj);
-};
-
 function parseArray(str, format) {
 
     //str should be an array since multiple query params of the same name were used, e.g. foo=bar1&foo=bar2

--- a/lib/swaggerUtil.js
+++ b/lib/swaggerUtil.js
@@ -158,6 +158,9 @@ function castValueFromString(schema, value) {
 
 exports.cast = castValueFromString;
 
+exports.deepClone = function (obj) {
+    return _.cloneDeep(obj);
+};
 
 function parseArray(str, format) {
 

--- a/services/swagger.js
+++ b/services/swagger.js
@@ -137,12 +137,12 @@ exports.addFormat = function (format, validationFunction) {
 
 function flattenModelDefinitions(definitions) {
     Object.keys(definitions).forEach(function (defn) {
-        var flattenedDefn = {};
         if (definitions[defn].hasOwnProperty('allOf')) {
+            var flattenedDefn = {};
             for (var i = 0; i < definitions[defn].allOf.length; i++) {
                 //have to clone so that inherited definitions are not affected
                 definitions[defn].allOf[i] = _.cloneDeep(definitions[defn].allOf[i]);
-                flattenModel(definitions[defn].allOf[i], flattenedDefn);
+                mergeToFlatModel(flattenedDefn, definitions[defn].allOf[i]);
             }
             flattenedDefn.required = Object.keys(flattenedDefn.required);
             definitions[defn] = flattenedDefn;
@@ -151,20 +151,20 @@ function flattenModelDefinitions(definitions) {
     });
 }
 
-function flattenModel(item, props) {
+function mergeToFlatModel(flatModel, model) {
     //have to convert 'required' array to object for merging purposes
-    if (item.required && Array.isArray(item.required)) {
-        var requiredObj = {};
-        item.required.reduce(function (prevVal, currentVal, idx) {
-            prevVal[currentVal] = idx;
-            return prevVal;
-        }, requiredObj);
-        item.required = requiredObj;
+    if (model.required && Array.isArray(model.required)) {
+        var requiredAsObj = {};
+        model.required.reduce(function (reqsAsObj, reqdPropName, arrayIndex) {
+            reqsAsObj[reqdPropName] = arrayIndex;
+            return reqsAsObj;
+        }, requiredAsObj);
+        model.required = requiredAsObj;
     }
-    _.merge(props, item);
-    if (item.hasOwnProperty('allOf')) {
-        item.allOf.forEach(function (subItem) {
-            flattenModel(subItem, props);
+    _.merge(flatModel, model);
+    if (model.hasOwnProperty('allOf')) {
+        model.allOf.forEach(function (subModel) {
+            mergeToFlatModel(flatModel, subModel);
         });
     }
 }

--- a/services/swagger.js
+++ b/services/swagger.js
@@ -154,12 +154,10 @@ function flattenModelDefinitions(definitions) {
 function mergeToFlatModel(flatModel, model) {
     //have to convert 'required' array to object for merging purposes
     if (model.required && Array.isArray(model.required)) {
-        var requiredAsObj = {};
-        model.required.reduce(function (reqsAsObj, reqdPropName, arrayIndex) {
+        model.required = model.required.reduce(function (reqsAsObj, reqdPropName, arrayIndex) {
             reqsAsObj[reqdPropName] = arrayIndex;
             return reqsAsObj;
-        }, requiredAsObj);
-        model.required = requiredAsObj;
+        }, {});
     }
     _.merge(flatModel, model);
     if (model.hasOwnProperty('allOf')) {

--- a/services/swagger.js
+++ b/services/swagger.js
@@ -83,7 +83,7 @@ exports.init = function (logger, config, callback) {
                 if (polymorphicValidation !== 'off') {
                     getDiscriminatorObjectsForSchemas(dereferencedApi.paths, responseModelValidationLevel);
                 }
-                overridePropertiesForInheritingModels(dereferencedApi.definitions);
+                overrideInheritedProperties(dereferencedApi.definitions);
                 return swagCallback();
             })
             .catch(function (error) {
@@ -134,7 +134,7 @@ exports.addFormat = function (format, validationFunction) {
     tv4.addFormat(format, validationFunction);
 };
 
-function overridePropertiesForInheritingModels(definitions) {
+function overrideInheritedProperties(definitions) {
     Object.keys(definitions).forEach(function (defn) {
         var props = {};
         if (definitions[defn].hasOwnProperty('allOf')) {

--- a/test/unit/testSwaggerService.js
+++ b/test/unit/testSwaggerService.js
@@ -84,6 +84,14 @@ describe('Swagger spec building test', function () {
             'validation did not identify missing required property');
     });
 
+    it('Model properties can be overridden', function () {
+        var personDefn = swaggerService.getSimpleSpecs()['api-v1'].definitions.Person;
+        var enthusiasticPersonDefn = swaggerService.getSimpleSpecs()['api-v1'].definitions.EnthusiasticPerson;
+        //kind property should have been overriden by enthusiastic person
+        assert.notEqual(personDefn.properties.kind.enum, undefined);
+        assert.equal(enthusiasticPersonDefn.properties.kind.enum, undefined);
+    });
+
     it('Has a spec for each top-level spec file', function () {
         assert.equal(_.keys(swaggerService.getSimpleSpecs()).length, swaggerExampleSpecs);
         assert.equal(_.keys(swaggerService.getPrettySpecs()).length, swaggerExampleSpecs);

--- a/test/unit/testSwaggerService.js
+++ b/test/unit/testSwaggerService.js
@@ -85,11 +85,12 @@ describe('Swagger spec building test', function () {
     });
 
     it('Model properties can be overridden', function () {
-        var personDefn = swaggerService.getSimpleSpecs()['api-v1'].definitions.Person;
-        var enthusiasticPersonDefn = swaggerService.getSimpleSpecs()['api-v1'].definitions.EnthusiasticPerson;
-        //kind property should have been overriden by enthusiastic person
-        assert.notEqual(personDefn.properties.kind.enum, undefined);
-        assert.equal(enthusiasticPersonDefn.properties.kind.enum, undefined);
+        var curiousPersonDefn = swaggerService.getSimpleSpecs()['api-v1'].definitions.CuriousPerson;
+        //kind enum should have been overriden by curious person
+        //required property should contain curious person required properties AND
+         //any required properties from inherited models
+        assert.equal(curiousPersonDefn.properties.kind.enum[0], 'CuriousPerson');
+        assert.equal(curiousPersonDefn.required.length, 3);
     });
 
     it('Has a spec for each top-level spec file', function () {


### PR DESCRIPTION
When using inheritance in swagger, the inheriting model should be able to override inherited properties. 