### PR TITLE
Run integration tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "4.2"
+  - "4"
   - "5"
   - "6"
 sudo: false

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "api"
   ],
   "scripts": {
-    "test": "JUNIT_REPORT_PATH=tests-report.xml mocha --check-leaks --reporter mocha-jenkins-reporter --globals services,__appDir test/unit; npm run lint",
+    "test": "npm run test-style && npm run test-unit && npm run test-integration",
+    "test-unit": "JUNIT_REPORT_PATH=tests-report.xml mocha --check-leaks --reporter mocha-jenkins-reporter --globals services,__appDir test/unit",
     "test-integration": "mocha test/integration",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha --report html -- test/unit",
-    "lint": "eslint index.js auth examples handlers lib middleware services test testlib && echo lint complete."
+    "test-style": "eslint index.js auth examples handlers lib middleware services test testlib && echo lint complete."
   },
   "bin": {
     "blueoak-server": "bin/blueoak-server.js"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "PointSource LLC <github@pointsource.com>",
   "contributors": [
     "Sean Kennedy <sean.kennedy@pointsource.com>",
+    "Ryan Sheppard <ryan.sheppard@pointsource.com>",
     "Greg Considine <greg@greg-considine.com>",
     "Erik Daughtrey <erik.daughtrey@pointsource.com>",
     "Erin Bartholomew <erin.bartholomew@pointsource.com>",

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -20,7 +20,7 @@ exports.launch = function (fixtureName, opts, done) {
 
     var bosPath = path.resolve(__dirname, opts.exec);
     output = '';
-    lastLaunch = child_process.exec(bosPath,
+    lastLaunch = child_process.execFile(bosPath,
         {
             'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
             'env': opts.env

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -26,7 +26,7 @@ exports.launch = function (fixtureName, opts, done) {
             'env': opts.env
         },
         function (err, stdout, stderr) {
-            if (err) {
+            if (err && err.signal !== 'SIGTERM') {
                 console.warn(err, stderr);
             }
             output += stdout + stderr;
@@ -44,7 +44,7 @@ exports.finish = function (done) {
         child_process.exec('taskkill /PID ' + lastLaunch.pid + ' /T /F');
     }
     else {
-        lastLaunch.kill('SIGINT');
+        lastLaunch.kill('SIGTERM');
     }
 
     if (output) {

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -7,6 +7,15 @@ var path = require('path'),
 
 var lastLaunch, output;
 
+var spawner, execer;
+if (process.platform === 'win32') {
+    spawner = child_process.exec;
+    execer = 'node ';
+} else {
+    spawner = child_process.execFile;
+    execer = '';
+}
+
 exports.launch = function (fixtureName, opts, done) {
 
     //opts is optional
@@ -20,7 +29,7 @@ exports.launch = function (fixtureName, opts, done) {
 
     var bosPath = path.resolve(__dirname, opts.exec);
     output = '';
-    lastLaunch = child_process.execFile(bosPath,
+    lastLaunch = spawner(execer + bosPath,
         {
             'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
             'env': opts.env

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -26,7 +26,7 @@ exports.launch = function (fixtureName, opts, done) {
             'env': opts.env
         },
         function (err, stdout, stderr) {
-            if (err && err.signal !== 'SIGTERM') {
+            if (err && err.signal !== 'SIGKILL') {
                 console.warn(err, stderr);
             }
             output += stdout + stderr;
@@ -44,7 +44,7 @@ exports.finish = function (done) {
         child_process.exec('taskkill /PID ' + lastLaunch.pid + ' /T /F');
     }
     else {
-        lastLaunch.kill('SIGTERM');
+        lastLaunch.kill('SIGKILL');
     }
 
     if (output) {

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -26,7 +26,7 @@ exports.launch = function (fixtureName, opts, done) {
             'env': opts.env
         },
         function (err, stdout, stderr) {
-            if (err && err.signal !== 'SIGTERM') {
+            if (err && err.signal !== 'SIGINT') {
                 console.warn(JSON.stringify(err, 0, 2), '\n' + stderr);
             }
             output += stdout + stderr;
@@ -44,7 +44,7 @@ exports.finish = function (done) {
         child_process.exec('taskkill /PID ' + lastLaunch.pid + ' /T /F');
     }
     else {
-        lastLaunch.kill('SIGTERM');
+        lastLaunch.kill('SIGINT');
     }
 
     if (output) {

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -20,7 +20,7 @@ exports.launch = function (fixtureName, opts, done) {
 
     var bosPath = path.resolve(__dirname, opts.exec);
     output = '';
-    lastLaunch = child_process.exec('node ' + bosPath,
+    lastLaunch = child_process.exec(bosPath,
         {
             'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
             'env': opts.env

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -44,7 +44,7 @@ exports.finish = function (done) {
         child_process.exec('taskkill /PID ' + lastLaunch.pid + ' /T /F');
     }
     else {
-        lastLaunch.kill('SIGKILL');
+        child_process.exec('kill -9 ' + lastLaunch.pid);
     }
 
     if (output) {

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -26,8 +26,8 @@ exports.launch = function (fixtureName, opts, done) {
             'env': opts.env
         },
         function (err, stdout, stderr) {
-            if (err && err.signal !== 'SIGKILL') {
-                console.warn(err, stderr);
+            if (err && err.signal !== 'SIGTERM') {
+                console.warn(JSON.stringify(err, 0, 2), '\n' + stderr);
             }
             output += stdout + stderr;
         }
@@ -44,14 +44,14 @@ exports.finish = function (done) {
         child_process.exec('taskkill /PID ' + lastLaunch.pid + ' /T /F');
     }
     else {
-        child_process.exec('kill -9 ' + lastLaunch.pid);
+        lastLaunch.kill('SIGTERM');
     }
 
     if (output) {
         // there was an "error" on launch, just be done
         done();
     } else {
-        lastLaunch.on('exit', function (code, signal) {
+        lastLaunch.on('close', function (code, signal) {
             done();
         });
     }


### PR DESCRIPTION
- set the `npm test` command to run the integration tests, in addition to the unit tests and the style checker
  - required special handling of the test server in the integration tests on windows
  - as well as a change to how it's invoked and identified as complete for Travis
- add Ryan as a contributor
- add the latest node v4 as a test target