### PR TITLE
Handle form urlencoded data #72

### DIFF
--- a/examples/fileupload/swagger/upload.json
+++ b/examples/fileupload/swagger/upload.json
@@ -37,7 +37,9 @@
         ],
         "consumes": ["multipart/form-data"],
         "responses": {
-          "default": {}
+          "default": {
+            "description": "fail"
+          }
         },
         "produces": ["application/json"]
       }

--- a/handlers/_swagger.js
+++ b/handlers/_swagger.js
@@ -413,11 +413,6 @@ function registerRoute(app, auth, additionalMiddleware, method, path, data, allo
     });
 }
 
-//Check if a given route contains any formData parameters
-function containsFormData(routeData) {
-    return _.where(routeData.parameters, {in: 'formData'}).length > 0;
-}
-
 //Any parameter with a default that's not already defined will be set to the default value
 function setDefaultQueryParams(req, data, logger) {
     var parameters = _.toArray(data.parameters);

--- a/handlers/_swagger.js
+++ b/handlers/_swagger.js
@@ -70,14 +70,14 @@ exports.init = function (app, auth, config, logger, serviceLoader, swagger, call
 
         if (containsUrlEncodedFormData(api)) {
             var middlewareConfig = config.get('express').middleware;
-            var foundBodyParserInMiddlewareConfig = !(_.indexOf(middlewareConfig, 'body-parser') === -1 &&
-                _.indexOf(middlewareConfig, 'bodyParser') === -1);
+            var foundBodyParserInMiddlewareConfig = !(_.indexOf(middlewareConfig, 'body-parser') < 0 &&
+                _.indexOf(middlewareConfig, 'bodyParser') < 0);
             if (!foundBodyParserInMiddlewareConfig) {
                 logger.warn('Body parser not found in middleware config.  ' +
                     'Required when using MIME type application/www-form-urlencoded.');
             }
             var bodyParserConfig = _.extend({}, config.get('bodyParser'), config.get('body-parser'));
-            if (_.indexOf(_.keys(bodyParserConfig), 'urlencoded') === -1) {
+            if (_.indexOf(_.keys(bodyParserConfig), 'urlencoded') < 0) {
                 logger.warn('Body parser not configured to look for url encoded data.  ' +
                     'Required when using MIME type application/www-form-urlencoded.');
             }

--- a/handlers/_swagger.js
+++ b/handlers/_swagger.js
@@ -295,7 +295,9 @@ function registerRoute(app, auth, additionalMiddleware, method, path, data, allo
     additionalMiddleware = authMiddleware.concat(additionalMiddleware);
 
     if (_.indexOf(data.consumes, 'multipart/form-data') > -1) {
-        var fieldData = _.where(data.parameters, {in: 'formData', type: 'file'});
+        var fieldData = _.filter(data.parameters, function (param) {
+            return param.in === 'formData' && param.type === 'file';
+        });
         fieldData = _.map(fieldData, function(item) {
             return {
                 name: item.name,

--- a/handlers/_swagger.js
+++ b/handlers/_swagger.js
@@ -500,7 +500,6 @@ function validateRequestParameters(req, data, swaggerDoc, logger, callback) {
         } else if (parm.in === 'formData') {
             // fyi, the swagger parser will fail if the user didn't set 'consumes' to
             // multipart/form-data or application/x-www-form-urlencoded
-
             if (parm.required && parm.type === 'file') {
                 if (!req.files[parm.name]) {
                     logger.warn('Missing form parameter "%s" for operation "%s"', parm.name, data.operationId);
@@ -508,25 +507,25 @@ function validateRequestParameters(req, data, swaggerDoc, logger, callback) {
                     error.name = 'ValidationError';
                     return callback(error);
                 }
-            } else if (parm.required) { //something other than file
-                if (!req.body[parm.name]) { //multer puts the non-file parameters in the request body
+            }
+            else if (!req.body[parm.name]) { //multer puts the non-file parameters in the request body
+                if (parm.required) { //something other than file
                     logger.warn('Missing form parameter "%s" for operation "%s"', parm.name, data.operationId);
                     error = new VError('Missing %s form parameter', parm.name);
                     error.name = 'ValidationError';
                     return callback(error);
-                } else {
-                    //go through the param-parsing code which is able to take text and validate
-                    //it as any type, such as number, or array
-                    result = swaggerUtil.validateParameterType(parm, req.body[parm.name]);
-                    if (!result.valid) {
-                        error = new VError('Error validating form parameter %s', parm.name);
-                        error.name = 'ValidationError';
-                        error.subErrors = result.errors;
-                        return callback(error);
-                    }
+                }
+            } else {
+                //go through the param-parsing code which is able to take text and validate
+                //it as any type, such as number, or array
+                result = swaggerUtil.validateParameterType(parm, req.body[parm.name]);
+                if (!result.valid) {
+                    error = new VError('Error validating form parameter %s', parm.name);
+                    error.name = 'ValidationError';
+                    error.subErrors = result.errors;
+                    return callback(error);
                 }
             }
-
         } else if (parm.in === 'body') {
             result = swaggerUtil.validateJSONType(parm.schema, req.body);
             var polymorphicValidationErrors = [];

--- a/handlers/_swagger.js
+++ b/handlers/_swagger.js
@@ -70,8 +70,8 @@ exports.init = function (app, auth, config, logger, serviceLoader, swagger, call
 
         if (containsUrlEncodedFormData(api)) {
             var middlewareConfig = config.get('express').middleware;
-            var foundBodyParserInMiddlewareConfig = !(_.indexOf(middlewareConfig, 'body-parser') < 0 &&
-                _.indexOf(middlewareConfig, 'bodyParser') < 0);
+            var foundBodyParserInMiddlewareConfig = (_.indexOf(middlewareConfig, 'body-parser') >= 0 ||
+                _.indexOf(middlewareConfig, 'bodyParser') >= 0);
             if (!foundBodyParserInMiddlewareConfig) {
                 logger.warn('Body parser not found in middleware config.  ' +
                     'Required when using MIME type application/www-form-urlencoded.');

--- a/test/integration/fixtures/server8/common/swagger/petstore2.json
+++ b/test/integration/fixtures/server8/common/swagger/petstore2.json
@@ -52,6 +52,79 @@
             }
           }
         }
+      },
+      "put": {
+        "description": "upload a pet",
+        "operationId": "pets2Upload",
+        "consumes": ["multipart/form-data"],
+        "parameters": [
+          {
+            "in": "formData",
+            "type": "file",
+            "name": "pet"
+          },
+          {
+            "in": "formData",
+            "type": "number",
+            "name": "petId"
+          }
+        ],
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "save a pet",
+        "operationId": "pets2Post",
+        "parameters": [
+          {
+            "in": "formData",
+            "type": "string",
+            "name": "petName"
+          },
+          {
+            "in": "formData",
+            "type": "number",
+            "name": "petId"
+          }
+        ],
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
       }
     }
   },

--- a/test/integration/fixtures/server8/server/config/default.json
+++ b/test/integration/fixtures/server8/server/config/default.json
@@ -13,7 +13,12 @@
   },
 
   "bodyParser": {
-    "json": {}
+    "json": {},
+    "urlencoded": {}
+  },
+
+  "multer": {
+    "storage": "multerMemoryStorage"
   },
 
   "logger": {

--- a/test/integration/fixtures/server8/server/handlers/petstore.js
+++ b/test/integration/fixtures/server8/server/handlers/petstore.js
@@ -14,6 +14,14 @@ exports.pets2 = function(req, res, next) {
     });
 };
 
+exports.pets2Upload = function(req, res, next) {
+    res.json({petId: Number(req.body.petId), file: req.files.pet[0]});
+};
+
+exports.pets2Post = function(req, res, next) {
+    res.json({petId: Number(req.body.petId), name: req.body.petName});
+};
+
 exports.pets3 = function(req, res, next) {
     res.json({
         name: 'pets3'

--- a/test/integration/fixtures/server8/server/pet.txt
+++ b/test/integration/fixtures/server8/server/pet.txt
@@ -1,0 +1,1 @@
+Mr. Bigglesworth

--- a/test/integration/testSwagger.js
+++ b/test/integration/testSwagger.js
@@ -4,7 +4,9 @@
  */
 var request = require('request'),
     assert = require('assert'),
-    util = require('./launchUtil');
+    util = require('./launchUtil'),
+    fs = require('fs'),
+    path = require('path');
 
 describe('SERVER5 - test simple REST calls from swagger spec', function () {
     this.timeout(5000);
@@ -103,6 +105,41 @@ describe('SERVER8 - test swagger spec with blueoak project structure', function 
             assert.equal(null, err);
             var json = JSON.parse(body);
             assert.equal('pets2', json.name);
+            done();
+        });
+    });
+
+    it('PUT /api/pets2', function (done) {
+        var formData = {
+            pet: fs.createReadStream(path.join(__dirname, '/fixtures/server8/server/pet.txt')),
+            petId: '1'
+        };
+        request({
+            url: 'http://localhost:' + (process.env.PORT || 5000) + '/api/pets2',
+            method: 'PUT',
+            formData: formData
+        }, function (err, resp, body) {
+            assert.equal(null, err);
+            var json = JSON.parse(body);
+            assert(json.file);
+            assert.equal(json.petId, 1);
+            done();
+        });
+    });
+
+    it('POST /api/pets2', function (done) {
+        request({
+            url: 'http://localhost:' + (process.env.PORT || 5000) + '/api/pets2',
+            method: 'POST',
+            form: {
+                petId: 1,
+                petName: 'Mr. Bigglesworth'
+            }
+        }, function (err, resp, body) {
+            assert.equal(null, err);
+            var json = JSON.parse(body);
+            assert(json.petId === 1);
+            assert.equal(json.name, 'Mr. Bigglesworth');
             done();
         });
     });


### PR DESCRIPTION
Only use multer middleware on routes with multipart/form-data. Ensure that body parser is configured for url encoded form data. #72