### PR TITLE
turn off ref compiler in swagger example

### DIFF
--- a/examples/swagger/config/default.json
+++ b/examples/swagger/config/default.json
@@ -15,6 +15,23 @@
 
   "cluster": {
     "maxWorkers": 1
+  },
+
+  "swagger": {
+    "refCompiler": {
+      "petstore": {
+        "baseSpecFile": "petstore.json",
+        "refDirs": [
+          "v1-assets"
+        ]
+      },
+      "api-v1": {
+        "baseSpecFile": "api-v1.yaml",
+        "refDirs": [
+          "public"
+        ]
+      }
+    }
   }
 
 }

--- a/examples/swagger/config/default.json
+++ b/examples/swagger/config/default.json
@@ -15,23 +15,6 @@
 
   "cluster": {
     "maxWorkers": 1
-  },
-
-  "swagger": {
-    "refCompiler": {
-      "petstore": {
-        "baseSpecFile": "petstore.json",
-        "refDirs": [
-          "v1-assets"
-        ]
-      },
-      "api-v1": {
-        "baseSpecFile": "api-v1.yaml",
-        "refDirs": [
-          "public"
-        ]
-      }
-    }
   }
 
 }

--- a/examples/swagger/nodemon.json
+++ b/examples/swagger/nodemon.json
@@ -1,5 +1,5 @@
 {
     "ext": ".js,.json,.yaml,.xsl",
-    "ignore": ["*/node_modules/"],
+    "ignore": ["*/node_modules/", "swagger/petstore.json", "swagger/api-v1.yaml"],
     "watch": [".", "../../"]
 }


### PR DESCRIPTION
forgot to turn off ref compilation in the swagger example, so when someone new to BOS starts the example with nodemon it restarts endlessly. #78 