### PR TITLE
Add support for mocking services

### DIFF
--- a/bin/blueoak-server.js
+++ b/bin/blueoak-server.js
@@ -3,10 +3,21 @@
  * Copyright (c) 2015-2016 PointSource, LLC.
  * MIT Licensed
  */
+var parseArgs = require('minimist');
 var server = require('../');
 
+// parse arguments
+var argv = parseArgs(process.argv.slice(2));
+
+// convert mocks from CSV into an array
+var mocks = argv.mocks || argv.m;
+if (mocks) {
+    mocks = mocks.split(',');
+}
+
 server.init({
-    appDir: process.cwd()
+    appDir: process.cwd(),
+    mocks: mocks
 }, function(err) {
     if (err) {
         console.warn('Startup failed', err);

--- a/index.js
+++ b/index.js
@@ -32,6 +32,10 @@ module.exports.init = function (opts, callback) {
         global.__appDir = opts.appDir;
     }
 
+    if (opts.mocks) {
+        global.__mocks = opts.mocks;
+    }
+
     //Load the bootstrap services first (config and logging) since they're only needed for the master
     initServices({bootstrap: true}, function (err) {
         if (err) {
@@ -362,4 +366,3 @@ function checkNodeVersion(logger) {
 module.exports.testUtility = function () {
     return require('./testlib/util');
 };
-

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -161,6 +161,15 @@ function createLoader() {
             debug('Loading services from %s', dir);
             di.iterateOverJsFiles(dir, function(dir, file) {
                 var modPath = path.resolve(dir, file);
+
+                // load mock if appropriate
+                if (global.__mocks && global.__mocks.includes(file.substring(0, file.indexOf('.js')))) {
+                    var mock = path.resolve(global.__appDir, 'mocks', file);
+                    if (mock) {
+                        modPath = mock;
+                    }
+                }
+
                 var mod;
                 try {
                     mod = subRequire(modPath); //subRequire inserts the _id field
@@ -486,11 +495,11 @@ function createLoader() {
 }
 
 /*
- * Strips the prefix + suffix underscores from the service name, allowing you to inject the service 
- * without having to think of an alternative name.  For example, you can inject the logger service 
+ * Strips the prefix + suffix underscores from the service name, allowing you to inject the service
+ * without having to think of an alternative name.  For example, you can inject the logger service
  * as "_logger_" and still be free to assign the service to the variable "logger".
- * 
- * camelCamel strings are then coverted into dash-case. Based off of: 
+ *
+ * camelCamel strings are then coverted into dash-case. Based off of:
  * https://github.com/epeli/underscore.string/blob/master/dasherize.js
  */
 function normalizeServiceName(str) {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "express-static": "^1.0.3",
     "jsonwebtoken": "^5.4.1",
     "lodash": "^3.9.3",
+    "minimist": "^1.2.0",
     "multer": "^1.1.0",
     "node-cache": "^3.0.0",
     "node-statsd": "^0.1.1",

--- a/test/integration/fixtures/server12/config/default.json
+++ b/test/integration/fixtures/server12/config/default.json
@@ -1,0 +1,9 @@
+{
+  "express": {
+    "port": "5000"
+  },
+
+  "cluster": {
+    "maxWorkers": 1
+  }
+}

--- a/test/integration/fixtures/server12/mocks/dummyservice.js
+++ b/test/integration/fixtures/server12/mocks/dummyservice.js
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2015-2016 PointSource, LLC.
+ * MIT Licensed
+ */
+exports.init = function(logger) {
+    logger.info('Dummy Service Mock initialized');
+    process.exit(0); // exit test here
+};

--- a/test/integration/fixtures/server12/services/dummyservice.js
+++ b/test/integration/fixtures/server12/services/dummyservice.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2015-2016 PointSource, LLC.
+ * MIT Licensed
+ */
+exports.init = function() {
+    throw new Error('Dummy Service initialized');
+};

--- a/test/integration/launchUtil.js
+++ b/test/integration/launchUtil.js
@@ -27,9 +27,11 @@ exports.launch = function (fixtureName, opts, done) {
         opts.exec = '../../bin/blueoak-server.js';
     }
 
+    var args = opts.mocks ? ['--mocks', opts.mocks] : [];
+
     var bosPath = path.resolve(__dirname, opts.exec);
     output = '';
-    lastLaunch = spawner(execer + bosPath,
+    lastLaunch = spawner(execer + bosPath, args,
         {
             'cwd': path.resolve(__dirname, 'fixtures/' + fixtureName),
             'env': opts.env
@@ -42,13 +44,15 @@ exports.launch = function (fixtureName, opts, done) {
         }
     );
     setTimeout(function () {
-        // stack traces usually start with 'Error:', if there's that pattern, return it
-        output = /^Error:*/m.test(output) ? output : null;
+        if (!opts.fullOutput) {
+            // stack traces usually start with 'Error:', if there's that pattern, return it
+            output = /^Error:*/m.test(output) ? output : null;
+        }
         done(output);
     }, 4000);
 };
 
-exports.finish = function (done) {    
+exports.finish = function (done) {
     if (process.platform === 'win32') {
         child_process.exec('taskkill /PID ' + lastLaunch.pid + ' /T /F');
     }
@@ -65,4 +69,3 @@ exports.finish = function (done) {
         });
     }
 };
-

--- a/test/integration/testLoader.js
+++ b/test/integration/testLoader.js
@@ -80,3 +80,24 @@ describe('SERVER11 - middleware should get loaded from node modules', function (
         });
     });
 });
+
+describe('SERVER12 - mocks should get loaded when specified by the --mocks command line argument', function () {
+    this.timeout(5000);
+
+    after(function (done) {
+        util.finish(done);
+    });
+
+    it('Launch server and load mocks', function (done) {
+        util.launch('server12',
+            {
+                appDir: path.resolve(__dirname, 'fixtures/server12'),
+                mocks: 'dummyservice',
+                fullOutput: true
+            }, function(output) {
+                assert.ok(output.indexOf('Dummy Service Mock initialized') > -1);
+                assert.ok(output.indexOf('Dummy Service initialized') < 0);
+                done();
+            });
+    });
+});


### PR DESCRIPTION
1. Create mock services in the `mocks` directory. The name must match the service you wish to mock.
1. Pass comma delimited service names you wish to mock in the `mocks` command line argument.