### PR TITLE
Add support for CORS origins defined by regular expressions

### DIFF
--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -13,6 +13,17 @@ var cors = require('cors');
 
 exports.init = function(app, config, logger, callback) {
     var cfg = config.get('cors');
+
+    if (cfg.origin instanceof Array) {
+        // Convert any CORS origin defined with regex (i.e. starts with '^')
+        // from JSON string into an actual RegExp object.
+        for (var i = 0; i < cfg.origin.length; i++) {
+            if (cfg.origin[i].startsWith('^')) {
+                cfg.origin[i] = new RegExp(cfg.origin[i]);
+            }
+        }
+    }
+
     app.use(cors(cfg));
     logger.debug('Enabled CORS.');
     callback();


### PR DESCRIPTION
Currently, the config is defined in a JSON file. Therefore, all entries to the `cors.origins` array must be strings. However, the [CORS npm package](https://github.com/expressjs/cors#configuration-options) used in blueoak-server supports regular expressions as CORS origins. In order to utilize that functionality, this PR converts any string in the origin array into a RegExp if it starts with `^`.