### PR TITLE
Include body on Express response

### DIFF
--- a/handlers/_swagger.js
+++ b/handlers/_swagger.js
@@ -405,16 +405,25 @@ function registerRoute(app, auth, additionalMiddleware, method, path, data, allo
                         );
                     }
                     
+                    // attach the body for post-send() middlewares
+                    res.body = body;
+
                     // if we parsed JSON at the start, reJSONify
                     body = isBodyValid ? body : JSON.stringify(body);
+                } else {
+                    // attach the body for post-send() middlewares that aren't being swagger validated
+                    try {
+                        // make sure body is JSON object
+                        body = JSON.parse(body);
+                    } catch (err) {
+                        // not JSON stringified, so just attach body
+                        res.body = body;
+                    }
                 }
 
                 // after this initial call (sometimes `send` will call itself again),
                 // we don't need to get the response for validation anymore
                 res.send = responseSender;
-
-                // attach the body for post-send() middlewares
-                res.body = body;
 
                 // and call send()
                 responseSender.call(res, body);

--- a/handlers/_swagger.js
+++ b/handlers/_swagger.js
@@ -342,9 +342,9 @@ function registerRoute(app, auth, additionalMiddleware, method, path, data, allo
                             body = JSON.parse(body);
                         } catch (err) {
                             logger.error('Unexpected format when attempting to validate response');
-                            res.sentBody = body;
                             res.send = responseSender;
                             responseSender.call(res, body);
+                            res.sentBody = body;
                             return;
                         }
                     } else if (body) {

--- a/handlers/_swagger.js
+++ b/handlers/_swagger.js
@@ -414,7 +414,7 @@ function registerRoute(app, auth, additionalMiddleware, method, path, data, allo
                     // attach the body for post-send() middlewares that aren't being swagger validated
                     try {
                         // make sure body is JSON object
-                        body = JSON.parse(body);
+                        res.body = JSON.parse(body);
                     } catch (err) {
                         // not JSON stringified, so just attach body
                         res.body = body;


### PR DESCRIPTION
**Problem:**
1) When implementing a service that extends `blueoak-server`, handlers & middleware provided by the service do not have any way to see changes made to the response body during Swagger validation. That is, while we can configure middleware to "see" the Express response object after the body has been validated by `blueoak-server`, the post-validation body is not included in that object.
1) We would like to log/trace the actual response body that goes out over the wire

**Solution:**
Attach the body of the response to the Express response object so we can add middleware to trace the actual response body.

Note:
There are no automated tests for any of the functions in `registerRoute()`, and we haven't added any to this PR.