### PR TITLE
Add support for configuring embedded node.js http server timeout sett…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blueoak-server",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueoak-server",
-  "version": "2.12.1",
+  "version": "2.12.0",
   "description": "BlueOak Server",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueoak-server",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "BlueOak Server",
   "repository": {
     "type": "git",
@@ -19,7 +19,8 @@
     "Erin Bartholomew",
     "Greg Considine",
     "Benjamin Schell",
-    "Patrick Wolf"
+    "Patrick Wolf",
+    "David Roberts <david.roberts@globant.com>"
   ],
   "keywords": [
     "node",

--- a/services/express.js
+++ b/services/express.js
@@ -117,6 +117,21 @@ function startExpress(cfg, app, callback) {
             callback(err);
         });
     }
+
+    //Apply configuration file defined http-server settings to node server
+    if (cfg.httpServer) {
+        if (cfg.httpServer.timeout) {
+            server.timeout = cfg.httpServer.timeout;
+        }
+        if (cfg.httpServer.keepAliveTimeout) {
+            server.keepAliveTimeout = cfg.httpServer.keepAliveTimeout;
+        }
+        if (cfg.httpServer.headersTimeout) {
+            server.headersTimeout = cfg.httpServer.headersTimeout;
+        }
+        _logger.info('App configured with httpServer settings - timeout: %d, keepAliveTimeout: %d, headersTimeout: %d',
+            server.timeout, server.keepAliveTimeout, server.headersTimeout);
+    }
 }
 
 /**

--- a/services/express.js
+++ b/services/express.js
@@ -118,16 +118,17 @@ function startExpress(cfg, app, callback) {
         });
     }
 
-    //Apply configuration file defined http-server settings to node server
+    //Apply express/node http server timeouts from blueoak config, 
+    //see: https://nodejs.org/api/http.html#http_class_http_server
     if (cfg.httpServer) {
         if (cfg.httpServer.timeout) {
-            server.timeout = cfg.httpServer.timeout;
+            server.timeout = cfg.httpServer.timeout; // Node v0.9.12+
         }
         if (cfg.httpServer.keepAliveTimeout) {
-            server.keepAliveTimeout = cfg.httpServer.keepAliveTimeout;
+            server.keepAliveTimeout = cfg.httpServer.keepAliveTimeout; // Node v8.0.0+
         }
         if (cfg.httpServer.headersTimeout) {
-            server.headersTimeout = cfg.httpServer.headersTimeout;
+            server.headersTimeout = cfg.httpServer.headersTimeout; // Node v11.3.0+
         }
         _logger.info('App configured with httpServer settings - timeout: %d, keepAliveTimeout: %d, headersTimeout: %d',
             server.timeout, server.keepAliveTimeout, server.headersTimeout);

--- a/test/unit/fixtures/config/timeout/config/default.json
+++ b/test/unit/fixtures/config/timeout/config/default.json
@@ -1,0 +1,9 @@
+{
+"express": {
+    "httpServer": {
+      "timeout": 111111,
+      "keepAliveTimeout": 222222,
+      "headersTimeout": 333333
+    }
+  }
+}

--- a/test/unit/testConfig.js
+++ b/test/unit/testConfig.js
@@ -38,3 +38,29 @@ describe('Config test', function () {
 
 });
 
+describe('Node server timeout config test', function () {
+
+    //The logger will try to read global.__appDir, so make sure it's set
+    beforeEach(function() {
+        global.__appDir = path.resolve(__dirname, 'fixtures/config/timeout');
+    });
+
+    //restore __appDir to its original value
+    afterEach(function() {
+        global.__appDir = origAppDir;
+    });
+
+    it('Test timeout config', function (done) {
+
+        util.init(config, {}, _.noop, function() {
+            //timeout/default.json overrides default node timeout settings
+            assert.equal(config.get('express').httpServer.timeout, 111111);
+            assert.equal(config.get('express').httpServer.keepAliveTimeout, 222222);
+            assert.equal(config.get('express').httpServer.headersTimeout, 333333);
+
+            done();
+        });
+    });
+
+});
+


### PR DESCRIPTION
Enable support for configuring the express embedded node.js http server timeout settings via the BlueOak config file support.

Support included for the Node.js http server settings:

timeout (Node v0.9.12+)
keepAliveTimeout (v8.0.0+)
headersTimeout (v11.3.0+)
